### PR TITLE
migrate to dart 2.0 release

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Shinya Kumagai <roomful.rooms@gmail.com>
 homepage: https://github.com/droibit/flutter_custom_tabs
 
 environment:
-  sdk: ">=2.0.0-dev.28 <2.0.0"
+  sdk: ">=2.0.0-dev.28 <3.0.0"
   flutter: ">=0.1.4 <2.0.0"
 
 dependencies:


### PR DESCRIPTION
Tested with dart 2.0, `flutter analyze`gives no issues. Used following migration verification steps: https://www.dartlang.org/dart-2#migration