### PR TITLE
Migrate from deprecated gradle getGenerateBuildConfig to buildFeatures

### DIFF
--- a/flutter_custom_tabs/android/build.gradle
+++ b/flutter_custom_tabs/android/build.gradle
@@ -32,9 +32,8 @@ android {
         disable 'InvalidPackage'
     }
 
-    // TODO replace with https://issuetracker.google.com/issues/72050365 once released.
-    libraryVariants.all {
-        it.generateBuildConfig.enabled = false
+    buildFeatures {
+        buildConfig = false
     }
 
     dependencies {

--- a/flutter_custom_tabs/android/build.gradle
+++ b/flutter_custom_tabs/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:4.1.0'
     }
 }
 


### PR DESCRIPTION
Currently, the library is using `getGenerateBuildConfig` in the Android `build.gradle`.

That method is now deprecated in favour of `buildFeatures.buildConfig`.

```
> Configure project :flutter_custom_tabs
WARNING:API 'variant.getGenerateBuildConfig()' is obsolete and has been replaced with 'variant.getGenerateBuildConfigProvider()'.
It will be removed in version 7.0 of the Android Gradle plugin.
For more information, see https://d.android.com/r/tools/task-configuration-avoidance.
REASON: Called from: /Users/davidmigloz/flutter/.pub-cache/hosted/pub.dartlang.org/flutter_custom_tabs-1.0.2/android/build.gradle:37
WARNING: Debugging obsolete API calls can take time during configuration. It's recommended to not keep it on at all times.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
```