### PR TITLE
Add customisation for Android custom tabs: share state, sheet mode, t…

### DIFF
--- a/flutter_custom_tabs/CHANGELOG.md
+++ b/flutter_custom_tabs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+- Supports sheet mode style customization for Android Custom Tabs ([#91](https://github.com/droibit/flutter_custom_tabs/pull/91)).
+- Supports share state mode for Android Custom Tabs ([#91](https://github.com/droibit/flutter_custom_tabs/pull/91)).
+
 ## 1.2.0
 - Supports presentation style customization for SFSafariViewController([#85](https://github.com/droibit/flutter_custom_tabs/pull/85)).
 - Make `closeAllIfPossible` work on Android 6.0 and above([#86](https://github.com/droibit/flutter_custom_tabs/pull/86)).

--- a/flutter_custom_tabs/android/src/main/java/com/github/droibit/flutter/plugins/customtabs/CustomTabsFactory.java
+++ b/flutter_custom_tabs/android/src/main/java/com/github/droibit/flutter/plugins/customtabs/CustomTabsFactory.java
@@ -10,6 +10,7 @@ import androidx.annotation.AnimRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
 import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.browser.customtabs.CustomTabsSession;
 
 import com.droibit.android.customtabs.launcher.CustomTabsFallback;
 import com.droibit.android.customtabs.launcher.CustomTabsLauncher;
@@ -34,6 +35,10 @@ class CustomTabsFactory {
     private static final String KEY_ANIMATION_END_ENTER = "endEnter";
     private static final String KEY_ANIMATION_END_EXIT = "endExit";
     private static final String KEY_EXTRA_CUSTOM_TABS = "extraCustomTabs";
+    private static final String KEY_SHARE_STATE = "shareState";
+    private static final String KEY_INITIAL_HEIGHT_PX = "initialHeightPx";
+    private static final String KEY_HEIGHT_RESIZE_BEHAVIOUR = "heightResizeBehaviour";
+    private static final String KEY_TOOLBAR_CORNER_RADIUS_DP = "toolbarCornerRadiusDp";
 
     // Note: The full resource qualifier is "package:type/entry".
     // https://developer.android.com/reference/android/content/res/Resources.html#getIdentifier(java.lang.String, java.lang.String, java.lang.String)
@@ -46,8 +51,8 @@ class CustomTabsFactory {
     }
 
     @NonNull
-    CustomTabsIntent createIntent(@NonNull Map<String, Object> options) {
-        final CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
+    CustomTabsIntent createIntent(@NonNull Map<String, Object> options, CustomTabsSession session) {
+        final CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(session);
         if (options.containsKey(KEY_OPTIONS_TOOLBAR_COLOR)) {
             final String colorString = (String) options.get(KEY_OPTIONS_TOOLBAR_COLOR);
             builder.setToolbarColor(Color.parseColor(colorString));
@@ -78,6 +83,22 @@ class CustomTabsFactory {
         if (options.containsKey(KEY_CLOSE_BUTTON_POSITION)) {
             final int position = (int) options.get(KEY_CLOSE_BUTTON_POSITION);
             builder.setCloseButtonPosition(position);
+        }
+
+        if (options.containsKey(KEY_SHARE_STATE)) {
+            final int state = (int) options.get(KEY_SHARE_STATE);
+            builder.setShareState(state);
+        }
+
+        if (options.containsKey(KEY_INITIAL_HEIGHT_PX)) {
+            final int height = (int) options.get(KEY_INITIAL_HEIGHT_PX);
+            final int behaviour = (int) options.get(KEY_HEIGHT_RESIZE_BEHAVIOUR);
+            builder.setInitialActivityHeightPx(height, behaviour);
+        }
+
+        if (options.containsKey(KEY_TOOLBAR_CORNER_RADIUS_DP)) {
+            final int radius = (int) options.get(KEY_TOOLBAR_CORNER_RADIUS_DP);
+            builder.setToolbarCornerRadiusDp(radius);
         }
 
         final CustomTabsIntent customTabsIntent = builder.build();

--- a/flutter_custom_tabs/android/src/main/java/com/github/droibit/flutter/plugins/customtabs/helpers/CustomTabActivityHelper.java
+++ b/flutter_custom_tabs/android/src/main/java/com/github/droibit/flutter/plugins/customtabs/helpers/CustomTabActivityHelper.java
@@ -1,0 +1,152 @@
+package com.github.droibit.flutter.plugins.customtabs;
+
+import android.app.Activity;
+import android.net.Uri;
+import android.os.Bundle;
+
+import androidx.browser.customtabs.CustomTabsClient;
+import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.browser.customtabs.CustomTabsServiceConnection;
+import androidx.browser.customtabs.CustomTabsSession;
+
+import java.util.List;
+
+/**
+ * This is a helper class to manage the connection to the Custom Tabs Service.
+ *
+ * Source: https://github.com/GoogleChrome/android-browser-helper/tree/main/demos/custom-tabs-example-app
+ */
+public class CustomTabActivityHelper implements ServiceConnectionCallback {
+    private CustomTabsSession mCustomTabsSession;
+    private CustomTabsClient mClient;
+    private CustomTabsServiceConnection mConnection;
+    private ConnectionCallback mConnectionCallback;
+
+    /**
+     * Opens the URL on a Custom Tab if possible. Otherwise fallsback to opening it on a WebView.
+     *
+     * @param activity The host activity.
+     * @param customTabsIntent a CustomTabsIntent to be used if Custom Tabs is available.
+     * @param uri the Uri to be opened.
+     * @param fallback a CustomTabFallback to be used if Custom Tabs is not available.
+     */
+    public static void openCustomTab(Activity activity,
+                                     CustomTabsIntent customTabsIntent,
+                                     Uri uri,
+                                     CustomTabFallback fallback) {
+        String packageName = CustomTabsHelper.getPackageNameToUse(activity);
+
+        //If we cant find a package name, it means theres no browser that supports
+        //Chrome Custom Tabs installed. So, we fallback to the webview
+        if (packageName == null) {
+            if (fallback != null) {
+                fallback.openUri(activity, uri);
+            }
+        } else {
+            customTabsIntent.intent.setPackage(packageName);
+            customTabsIntent.launchUrl(activity, uri);
+        }
+    }
+
+    /**
+     * Unbinds the Activity from the Custom Tabs Service.
+     * @param activity the activity that is connected to the service.
+     */
+    public void unbindCustomTabsService(Activity activity) {
+        if (mConnection == null) return;
+        activity.unbindService(mConnection);
+        mClient = null;
+        mCustomTabsSession = null;
+        mConnection = null;
+    }
+
+    /**
+     * Creates or retrieves an exiting CustomTabsSession.
+     *
+     * @return a CustomTabsSession.
+     */
+    public CustomTabsSession getSession() {
+        if (mClient == null) {
+            mCustomTabsSession = null;
+        } else if (mCustomTabsSession == null) {
+            mCustomTabsSession = mClient.newSession(null);
+        }
+        return mCustomTabsSession;
+    }
+
+    /**
+     * Register a Callback to be called when connected or disconnected from the Custom Tabs Service.
+     */
+    public void setConnectionCallback(ConnectionCallback connectionCallback) {
+        this.mConnectionCallback = connectionCallback;
+    }
+
+    /**
+     * Binds the Activity to the Custom Tabs Service.
+     * @param activity the activity to be binded to the service.
+     */
+    public void bindCustomTabsService(Activity activity) {
+        if (mClient != null) return;
+
+        String packageName = CustomTabsHelper.getPackageNameToUse(activity);
+        if (packageName == null) return;
+
+        mConnection = new ServiceConnection(this);
+        CustomTabsClient.bindCustomTabsService(activity, packageName, mConnection);
+    }
+
+    /**
+     * @see {@link CustomTabsSession#mayLaunchUrl(Uri, Bundle, List)}.
+     * @return true if call to mayLaunchUrl was accepted.
+     */
+    public boolean mayLaunchUrl(Uri uri, Bundle extras, List<Bundle> otherLikelyBundles) {
+        if (mClient == null) return false;
+
+        CustomTabsSession session = getSession();
+        if (session == null) return false;
+
+        return session.mayLaunchUrl(uri, extras, otherLikelyBundles);
+    }
+
+    @Override
+    public void onServiceConnected(CustomTabsClient client) {
+        mClient = client;
+        mClient.warmup(0L);
+        if (mConnectionCallback != null) mConnectionCallback.onCustomTabsConnected();
+    }
+
+    @Override
+    public void onServiceDisconnected() {
+        mClient = null;
+        mCustomTabsSession = null;
+        if (mConnectionCallback != null) mConnectionCallback.onCustomTabsDisconnected();
+    }
+
+    /**
+     * A Callback for when the service is connected or disconnected. Use those callbacks to
+     * handle UI changes when the service is connected or disconnected.
+     */
+    public interface ConnectionCallback {
+        /**
+         * Called when the service is connected.
+         */
+        void onCustomTabsConnected();
+
+        /**
+         * Called when the service is disconnected.
+         */
+        void onCustomTabsDisconnected();
+    }
+
+    /**
+     * To be used as a fallback to open the Uri when Custom Tabs is not available.
+     */
+    public interface CustomTabFallback {
+        /**
+         *
+         * @param activity The Activity that wants to open the Uri.
+         * @param uri The uri to be opened by the fallback.
+         */
+        void openUri(Activity activity, Uri uri);
+    }
+}

--- a/flutter_custom_tabs/android/src/main/java/com/github/droibit/flutter/plugins/customtabs/helpers/CustomTabsHelper.java
+++ b/flutter_custom_tabs/android/src/main/java/com/github/droibit/flutter/plugins/customtabs/helpers/CustomTabsHelper.java
@@ -1,0 +1,123 @@
+package com.github.droibit.flutter.plugins.customtabs;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.net.Uri;
+import android.text.TextUtils;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper class for Custom Tabs.
+ *
+ * Source: https://github.com/GoogleChrome/android-browser-helper/tree/main/demos/custom-tabs-example-app
+ */
+public class CustomTabsHelper {
+    private static final String TAG = "CustomTabsHelper";
+    static final String STABLE_PACKAGE = "com.android.chrome";
+    static final String BETA_PACKAGE = "com.chrome.beta";
+    static final String DEV_PACKAGE = "com.chrome.dev";
+    static final String LOCAL_PACKAGE = "com.google.android.apps.chrome";
+    private static final String EXTRA_CUSTOM_TABS_KEEP_ALIVE =
+            "android.support.customtabs.extra.KEEP_ALIVE";
+    private static final String ACTION_CUSTOM_TABS_CONNECTION =
+            "android.support.customtabs.action.CustomTabsService";
+
+    private static String sPackageNameToUse;
+
+    private CustomTabsHelper() {}
+
+    public static void addKeepAliveExtra(Context context, Intent intent) {
+        Intent keepAliveIntent = new Intent().setClassName(
+                context.getPackageName(), KeepAliveService.class.getCanonicalName());
+        intent.putExtra(EXTRA_CUSTOM_TABS_KEEP_ALIVE, keepAliveIntent);
+    }
+
+    /**
+     * Goes through all apps that handle VIEW intents and have a warmup service. Picks
+     * the one chosen by the user if there is one, otherwise makes a best effort to return a
+     * valid package name.
+     *
+     * This is <strong>not</strong> threadsafe.
+     *
+     * @param context {@link Context} to use for accessing {@link PackageManager}.
+     * @return The package name recommended to use for connecting to custom tabs related components.
+     */
+    public static String getPackageNameToUse(Context context) {
+        if (sPackageNameToUse != null) return sPackageNameToUse;
+
+        PackageManager pm = context.getPackageManager();
+        // Get default VIEW intent handler.
+        Intent activityIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.example.com"));
+        ResolveInfo defaultViewHandlerInfo = pm.resolveActivity(activityIntent, 0);
+        String defaultViewHandlerPackageName = null;
+        if (defaultViewHandlerInfo != null) {
+            defaultViewHandlerPackageName = defaultViewHandlerInfo.activityInfo.packageName;
+        }
+
+        // Get all apps that can handle VIEW intents.
+        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(activityIntent, 0);
+        List<String> packagesSupportingCustomTabs = new ArrayList<>();
+        for (ResolveInfo info : resolvedActivityList) {
+            Intent serviceIntent = new Intent();
+            serviceIntent.setAction(ACTION_CUSTOM_TABS_CONNECTION);
+            serviceIntent.setPackage(info.activityInfo.packageName);
+            if (pm.resolveService(serviceIntent, 0) != null) {
+                packagesSupportingCustomTabs.add(info.activityInfo.packageName);
+            }
+        }
+
+        // Now packagesSupportingCustomTabs contains all apps that can handle both VIEW intents
+        // and service calls. Prefer the default browser if it supports Custom Tabs.
+        if (packagesSupportingCustomTabs.isEmpty()) {
+            sPackageNameToUse = null;
+        } else if (!TextUtils.isEmpty(defaultViewHandlerPackageName)
+                && !hasSpecializedHandlerIntents(context, activityIntent)
+                && packagesSupportingCustomTabs.contains(defaultViewHandlerPackageName)) {
+            sPackageNameToUse = defaultViewHandlerPackageName;
+        } else {
+            // Otherwise, pick the next favorite Custom Tabs provider.
+            sPackageNameToUse = packagesSupportingCustomTabs.get(0);
+        }
+        return sPackageNameToUse;
+    }
+
+    /**
+     * Used to check whether there is a specialized handler for a given intent.
+     * @param intent The intent to check with.
+     * @return Whether there is a specialized handler for the given intent.
+     */
+    private static boolean hasSpecializedHandlerIntents(Context context, Intent intent) {
+        try {
+            PackageManager pm = context.getPackageManager();
+            List<ResolveInfo> handlers = pm.queryIntentActivities(
+                    intent,
+                    PackageManager.GET_RESOLVED_FILTER);
+            if (handlers.size() == 0) {
+                return false;
+            }
+            for (ResolveInfo resolveInfo : handlers) {
+                IntentFilter filter = resolveInfo.filter;
+                if (filter == null) continue;
+                if (filter.countDataAuthorities() == 0 || filter.countDataPaths() == 0) continue;
+                if (resolveInfo.activityInfo == null) continue;
+                return true;
+            }
+        } catch (RuntimeException e) {
+            Log.e(TAG, "Runtime exception while getting specialized handlers");
+        }
+        return false;
+    }
+
+    /**
+     * @return All possible chrome package names that provide custom tabs feature.
+     */
+    public static String[] getPackages() {
+        return new String[]{"", STABLE_PACKAGE, BETA_PACKAGE, DEV_PACKAGE, LOCAL_PACKAGE};
+    }
+}

--- a/flutter_custom_tabs/android/src/main/java/com/github/droibit/flutter/plugins/customtabs/helpers/KeepAliveService.java
+++ b/flutter_custom_tabs/android/src/main/java/com/github/droibit/flutter/plugins/customtabs/helpers/KeepAliveService.java
@@ -1,0 +1,20 @@
+package com.github.droibit.flutter.plugins.customtabs;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.Binder;
+import android.os.IBinder;
+
+/**
+ * Empty service used by the custom tab to bind to, raising the application's importance.
+ *
+ * Source: https://github.com/GoogleChrome/android-browser-helper/tree/main/demos/custom-tabs-example-app
+ */
+public class KeepAliveService extends Service {
+    private static final Binder sBinder = new Binder();
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return sBinder;
+    }
+}

--- a/flutter_custom_tabs/android/src/main/java/com/github/droibit/flutter/plugins/customtabs/helpers/ServiceConnection.java
+++ b/flutter_custom_tabs/android/src/main/java/com/github/droibit/flutter/plugins/customtabs/helpers/ServiceConnection.java
@@ -1,0 +1,36 @@
+package com.github.droibit.flutter.plugins.customtabs;
+
+import android.content.ComponentName;
+
+import androidx.annotation.NonNull;
+import androidx.browser.customtabs.CustomTabsClient;
+import androidx.browser.customtabs.CustomTabsServiceConnection;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Implementation for the CustomTabsServiceConnection that avoids leaking the
+ * ServiceConnectionCallback
+ *
+ * Source: https://github.com/GoogleChrome/android-browser-helper/tree/main/demos/custom-tabs-example-app
+ */
+public class ServiceConnection extends CustomTabsServiceConnection {
+    // A weak reference to the ServiceConnectionCallback to avoid leaking it.
+    private WeakReference<ServiceConnectionCallback> mConnectionCallback;
+
+    public ServiceConnection(ServiceConnectionCallback connectionCallback) {
+        mConnectionCallback = new WeakReference<>(connectionCallback);
+    }
+
+    @Override
+    public void onCustomTabsServiceConnected(@NonNull ComponentName name, @NonNull CustomTabsClient client) {
+        ServiceConnectionCallback connectionCallback = mConnectionCallback.get();
+        if (connectionCallback != null) connectionCallback.onServiceConnected(client);
+    }
+
+    @Override
+    public void onServiceDisconnected(ComponentName name) {
+        ServiceConnectionCallback connectionCallback = mConnectionCallback.get();
+        if (connectionCallback != null) connectionCallback.onServiceDisconnected();
+    }
+}

--- a/flutter_custom_tabs/android/src/main/java/com/github/droibit/flutter/plugins/customtabs/helpers/ServiceConnectionCallback.java
+++ b/flutter_custom_tabs/android/src/main/java/com/github/droibit/flutter/plugins/customtabs/helpers/ServiceConnectionCallback.java
@@ -1,0 +1,21 @@
+package com.github.droibit.flutter.plugins.customtabs;
+
+import androidx.browser.customtabs.CustomTabsClient;
+
+/**
+ * Callback for events when connecting and disconnecting from Custom Tabs Service.
+ *
+ * Source: https://github.com/GoogleChrome/android-browser-helper/tree/main/demos/custom-tabs-example-app
+ */
+public interface ServiceConnectionCallback {
+    /**
+     * Called when the service is connected.
+     * @param client a CustomTabsClient
+     */
+    void onServiceConnected(CustomTabsClient client);
+
+    /**
+     * Called when the service is disconnected.
+     */
+    void onServiceDisconnected();
+}

--- a/flutter_custom_tabs/lib/flutter_custom_tabs.dart
+++ b/flutter_custom_tabs/lib/flutter_custom_tabs.dart
@@ -1,9 +1,12 @@
 export 'package:flutter_custom_tabs_platform_interface/flutter_custom_tabs_platform_interface.dart'
     show
-        CustomTabsOption,
+        ActivityHeightResizeBehaviour,
+        CustomTabsAnimation,
         CustomTabsCloseButtonPosition,
-        SafariViewControllerOption,
+        CustomTabsOption,
+        CustomTabsShareState,
         SafariViewControllerDismissButtonStyle,
+        SafariViewControllerOption,
         ViewControllerModalPresentationStyle;
 
 export 'src/custom_tabs_option.dart';

--- a/flutter_custom_tabs/pubspec.yaml
+++ b/flutter_custom_tabs/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_custom_tabs_platform_interface: ^1.2.0
+  flutter_custom_tabs_platform_interface: ^1.3.0
   flutter_custom_tabs_web: ^1.1.0
   meta: ^1.9.1
 

--- a/flutter_custom_tabs_platform_interface/CHANGELOG.md
+++ b/flutter_custom_tabs_platform_interface/CHANGELOG.md
@@ -1,7 +1,13 @@
+## 1.3.0
+
+- Added `shareState` to `CustomTabsOption` to customize the presentation style([#91](https://github.com/droibit/flutter_custom_tabs/pull/91)).
+- Added `initialHeightPx` to `CustomTabsOption` to customize the presentation style([#91](https://github.com/droibit/flutter_custom_tabs/pull/91)).
+- Added `heightResizeBehaviour` to `CustomTabsOption` to customize the presentation style([#91](https://github.com/droibit/flutter_custom_tabs/pull/91)).
+- Added `toolbarCornerRadiusDp` to `CustomTabsOption` to customize the presentation style([#91](https://github.com/droibit/flutter_custom_tabs/pull/91)).
+
 ## 1.2.0
 
 - Added `modalPresentationStyle` to `SafariViewControllerOption` to customize the presentation style([#85](https://github.com/droibit/flutter_custom_tabs/pull/85)).
-
 
 ## 1.1.0
 

--- a/flutter_custom_tabs_platform_interface/lib/src/custom_tabs_option.dart
+++ b/flutter_custom_tabs_platform_interface/lib/src/custom_tabs_option.dart
@@ -20,6 +20,10 @@ class CustomTabsOption {
     this.animation,
     this.extraCustomTabs,
     this.headers,
+    this.shareState,
+    this.initialHeightPx,
+    this.heightResizeBehaviour,
+    this.toolbarCornerRadiusDp
   });
 
   /// Custom tab toolbar color.
@@ -48,6 +52,29 @@ class CustomTabsOption {
 
   /// Request Headers
   final Map<String, String>? headers;
+
+  /// Define share state for the custom tabs browser.
+  /// **This applies only on Android platform.**
+  ///
+  /// See also:
+  ///
+  /// * https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsIntent.Builder#setShareState(int)
+  ///
+  final CustomTabsShareState? shareState;
+
+  /// Extra that, if set, makes the Custom Tab Activity's height to be x pixels, the Custom Tab
+  /// will behave as a bottom sheet. x will be clamped between 50% and 100% of screen height.
+  /// Bottom sheet does not take effect in landscape mode or in multi-window mode.
+  final int? initialHeightPx;
+
+  /// Extra that, if set in combination with [initialHeightPx],
+  /// defines the height resize behavior of the Custom Tab Activity when
+  /// it behaves as a bottom sheet. Default is [ActivityHeightResizeBehaviour.defaultBehaviour].
+  final ActivityHeightResizeBehaviour? heightResizeBehaviour;
+
+  /// Extra that sets the toolbar's top corner radii in dp. This will only have
+  /// effect if the custom tab is behaving as a bottom sheet. Currently, this is capped at 16dp.
+  final int? toolbarCornerRadiusDp;
 
   @internal
   Map<String, dynamic> toMap() {
@@ -79,6 +106,20 @@ class CustomTabsOption {
     if (headers != null) {
       dest['headers'] = headers;
     }
+    if (shareState != null) {
+      dest['shareState'] = shareState!.index;
+    }
+    if (initialHeightPx != null) {
+      dest['initialHeightPx'] = initialHeightPx;
+    }
+    final behaviour = heightResizeBehaviour?.index ??
+        ActivityHeightResizeBehaviour.defaultBehaviour.index;
+    dest['heightResizeBehaviour'] = behaviour;
+
+    if (toolbarCornerRadiusDp != null) {
+      dest['toolbarCornerRadiusDp'] = toolbarCornerRadiusDp;
+    }
+
     return dest;
   }
 }
@@ -146,4 +187,18 @@ extension CustomTabsCloseButtonPositionRawValue
         return 2;
     }
   }
+}
+
+/// Define share state for the custom tabs browser.
+enum CustomTabsShareState {
+  defaultState,
+  on,
+  off,
+}
+
+/// Define activity resize behaviour when set along with [initialHeightPx]
+enum ActivityHeightResizeBehaviour {
+  defaultBehaviour,
+  adjustable,
+  fixed,
 }

--- a/flutter_custom_tabs_platform_interface/pubspec.yaml
+++ b/flutter_custom_tabs_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_custom_tabs_platform_interface
 description: A common platform interface for the flutter_custom_tabs plugin.
-version: 1.2.0
+version: 1.3.0
 homepage: https://github.com/droibit/flutter_custom_tabs
 
 environment:


### PR DESCRIPTION
Add customisation for Android custom tabs
- share state
- sheet mode (requires session)
- toolbar corner radius

Part of the session creation is taken directly from googles example.

Check fails due to dependencies issue. When new version of interface will be published it will work.