### PR TITLE
Update androidx.browser:browser to version 1.6.0

### DIFF
--- a/flutter_custom_tabs/example/android/app/build.gradle
+++ b/flutter_custom_tabs/example/android/app/build.gradle
@@ -31,9 +31,10 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdk flutter.minSdkVersion
-        targetSdk flutter.targetSdkVersion
+        targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        multiDexEnabled true
     }
 
     buildTypes {
@@ -53,4 +54,6 @@ flutter {
     source '../..'
 }
 
-dependencies {}
+dependencies {
+    implementation 'androidx.multidex:multidex:2.0.1'
+}

--- a/flutter_custom_tabs_android/android/build.gradle
+++ b/flutter_custom_tabs_android/android/build.gradle
@@ -27,7 +27,7 @@ android {
         namespace 'com.github.droibit.plugins.flutter.customtabs'
     }
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 19
@@ -48,7 +48,7 @@ android {
     }
 
     dependencies {
-        implementation 'androidx.browser:browser:1.5.0'
+        implementation 'androidx.browser:browser:1.6.0'
         implementation 'com.github.droibit:customtabslauncher:2.0.0-rc01'
 
         testImplementation 'junit:junit:4.13.2'

--- a/flutter_custom_tabs_android/example/android/app/build.gradle
+++ b/flutter_custom_tabs_android/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.github.droibit.plugins.flutter.customtabs.android.example"
-    compileSdk flutter.compileSdkVersion
+    compileSdk 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -37,9 +37,10 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdk flutter.minSdkVersion
-        targetSdk flutter.targetSdkVersion
+        targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        multiDexEnabled true
     }
 
     buildTypes {
@@ -49,6 +50,10 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
+    }
+
+    dependencies {
+        implementation 'androidx.multidex:multidex:2.0.1'
     }
 }
 


### PR DESCRIPTION
We would highly appreciate to update the version of `androidx.browser:browser` to `1.6.0`. We have another library in our project which is in conflict with the version.

Unfortunately i had to upgrade the `targetSdk` version to `34` and had to enable multiDex for the example apps. Actually there is a newer version `1.7.0` but i tried to keep the changes as small as possible.

Changes: 
https://developer.android.com/jetpack/androidx/releases/browser#version_16_2