### PR TITLE
Modernize CI pipelines with latest actions

### DIFF
--- a/.github/workflows/android_implementation_package.yml
+++ b/.github/workflows/android_implementation_package.yml
@@ -16,8 +16,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: 17    

--- a/.github/workflows/app_facing_package.yml
+++ b/.github/workflows/app_facing_package.yml
@@ -14,10 +14,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: 17

--- a/.github/workflows/ios_implementation_package.yml
+++ b/.github/workflows/ios_implementation_package.yml
@@ -14,9 +14,9 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'

--- a/.github/workflows/platform_interface_package.yml
+++ b/.github/workflows/platform_interface_package.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'

--- a/.github/workflows/web_implementation_package.yml
+++ b/.github/workflows/web_implementation_package.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'


### PR DESCRIPTION
- Update GitHub Actions versions in all workflow files:
  - checkout@v3 -> checkout@v4
  - setup-java@v3 -> setup-java@v4
- Bump Java version to 17 in all workflows.
- Update macOS runners to macos-14 where applicable.