### PR TITLE
Bump `flutter_custom_tabs` version to 2.2.1

### DIFF
--- a/flutter_custom_tabs/CHANGELOG.md
+++ b/flutter_custom_tabs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+
+- No changes except for version bump.
+
 ## 2.2.0
 
 - Updates minimum required `flutter_custom_tabs_android/ios/web` version to 2.2.0.

--- a/flutter_custom_tabs/README.md
+++ b/flutter_custom_tabs/README.md
@@ -21,7 +21,7 @@ Add `flutter_custom_tabs` to the dependencies of your `pubspec.yaml`.
 
 ``` yaml
 dependencies:
-  flutter_custom_tabs: ^2.2.0
+  flutter_custom_tabs: ^2.2.1
 ```
 
 > [!IMPORTANT]  

--- a/flutter_custom_tabs/pubspec.yaml
+++ b/flutter_custom_tabs/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_custom_tabs
 description: A Flutter plugin for mobile apps to launch a URL in Custom Tabs/SFSafariViewController.
-version: 2.2.0
+version: 2.2.1
 homepage: https://github.com/droibit/flutter_custom_tabs
 repository: https://github.com/droibit/flutter_custom_tabs/tree/main/flutter_custom_tabs
 issue_tracker: https://github.com/droibit/flutter_custom_tabs/issues


### PR DESCRIPTION
This release includes no code changes and is intended to address a warning related to the `publish_to` field in the pubspec.yaml file, thereby improving the package's score on pub.dev.