### PR TITLE
Keep `package:meta` import for Flutter <3.35

### DIFF
--- a/flutter_custom_tabs_android/lib/src/types/custom_tabs_color_schemes.dart
+++ b/flutter_custom_tabs_android/lib/src/types/custom_tabs_color_schemes.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
+// `@internal` is exported from `package:flutter/foundation.dart`
+// in Flutter >= 3.35.0; keep `meta` import for older SDKs (backcompat).
+// ignore: unnecessary_import
 import 'package:meta/meta.dart';
 
 /// The configuration of a Custom Tab visualization.


### PR DESCRIPTION
Keep the explicit `package:meta` import for backward compatibility with Flutter versions older than 3.35.0, where the `@internal` annotation is provided by the `meta` package. Suppress the analyzer `unnecessary_import` warning on newer SDKs that re-export `@internal` from `package:flutter/foundation.dart`. 