### PR TITLE
Add gradle-wrapper.properties and set Gradle to 8.13

### DIFF
--- a/flutter_custom_tabs/example/android/.gitignore
+++ b/flutter_custom_tabs/example/android/.gitignore
@@ -21,4 +21,5 @@ gradlew.bat
 .cxx/
 
 # Flutter files
+build/
 GeneratedPluginRegistrant.java

--- a/flutter_custom_tabs/example/android/.gitignore
+++ b/flutter_custom_tabs/example/android/.gitignore
@@ -13,14 +13,12 @@ local.properties
 projectFilesBackup/
 output.json
 
-# Gradle files
-/.gradle
-/build
-/gradle
-/gradlew
-/gradlew.bat
-
-.DS_Store
+# Gradle
+**/gradle-wrapper.jar
+.gradle/
+gradlew
+gradlew.bat
+.cxx/
 
 # Flutter files
 GeneratedPluginRegistrant.java

--- a/flutter_custom_tabs/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_custom_tabs/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip

--- a/flutter_custom_tabs_android/example/android/.gitignore
+++ b/flutter_custom_tabs_android/example/android/.gitignore
@@ -21,4 +21,5 @@ gradlew.bat
 .cxx/
 
 # Flutter files
+build/
 GeneratedPluginRegistrant.java

--- a/flutter_custom_tabs_android/example/android/.gitignore
+++ b/flutter_custom_tabs_android/example/android/.gitignore
@@ -13,14 +13,12 @@ local.properties
 projectFilesBackup/
 output.json
 
-# Gradle files
-/.gradle
-/build
-/gradle
-/gradlew
-/gradlew.bat
-
-.DS_Store
+# Gradle
+**/gradle-wrapper.jar
+.gradle/
+gradlew
+gradlew.bat
+.cxx/
 
 # Flutter files
 GeneratedPluginRegistrant.java

--- a/flutter_custom_tabs_android/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_custom_tabs_android/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip


### PR DESCRIPTION
This pull request updates Gradle configuration and related `.gitignore` rules for the Android example projects in both `flutter_custom_tabs` and `flutter_custom_tabs_android`. The main changes focus on standardizing Gradle wrapper usage and improving the `.gitignore` patterns to better handle Gradle and build artifacts.

Gradle configuration updates:

* Added a `gradle-wrapper.properties` file specifying Gradle 8.13 and standard wrapper settings in both `flutter_custom_tabs/example/android/gradle/wrapper/` and `flutter_custom_tabs_android/example/android/gradle/wrapper/`.

.gitignore improvements:

* Updated `.gitignore` files in both `flutter_custom_tabs/example/android/` and `flutter_custom_tabs_android/example/android/` to ignore Gradle wrapper files and directories more precisely, including `**/gradle-wrapper.jar`, `.gradle/`, `.cxx/`, `gradlew`, and `gradlew.bat`, while removing outdated or redundant patterns.