### PR TITLE
Bump Kotlin to 1.8.22 in example Android settings

### DIFF
--- a/flutter_custom_tabs/example/android/settings.gradle
+++ b/flutter_custom_tabs/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
   id "dev.flutter.flutter-plugin-loader" version "1.0.0"
   id "com.android.application" version "8.1.4" apply false
-  id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+  id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 
 include ":app"

--- a/flutter_custom_tabs_android/example/android/settings.gradle
+++ b/flutter_custom_tabs_android/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
   id "dev.flutter.flutter-plugin-loader" version "1.0.0"
   id "com.android.application" version "8.1.4" apply false
-  id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+  id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 
 include ":app"


### PR DESCRIPTION
Update the Kotlin Gradle plugin version in the example Android `settings.gradle` files to `1.8.22` to satisfy Flutter's minimum supported Kotlin version (observed when building on Flutter 3.38.x in CI). This fixes the build-time error indicating the project's Kotlin version is lower than Flutter's required minimum. See CI error and Flutter tool message for context.
- https://github.com/droibit/flutter_custom_tabs/actions/runs/19614424383/job/56164953510